### PR TITLE
Add License for GitHub Action

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 Merly.ai
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/readme.md
+++ b/readme.md
@@ -84,4 +84,4 @@ docker run --rm \
 
 ## 📄 License
 
-MIT © Merly.ai
+[Apache License 2.0](LICENSE) © Merly.ai


### PR DESCRIPTION
* Add Apache 2 license for compatibility with Merly legal concerns and GitHub Marketplace
